### PR TITLE
Add mempool_txs RPC endpoint that provides extra info about the mempool

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -529,10 +529,10 @@ func (mem *Mempool) ReapMaxTxs(max int) types.Txs {
 	return txs
 }
 
-// ReapMaxTxsWithExtInfo reaps up to max transactions (with additional metadata) from the mempool.
+// GetTxsWithExtInfo returns up to max transactions (with additional metadata) from the mempool.
 // If max is negative, there is no cap on the size of all returned
 // transactions (~ all available transactions).
-func (mem *Mempool) ReapMaxTxsWithExtInfo(max int) []MempoolTxInfo {
+func (mem *Mempool) GetTxsWithExtInfo(max int) []MempoolTxInfo {
 	mem.proxyMtx.Lock()
 	defer mem.proxyMtx.Unlock()
 

--- a/mempool/types.go
+++ b/mempool/types.go
@@ -1,0 +1,10 @@
+package mempool
+
+import (
+	"github.com/tendermint/tendermint/types"
+)
+
+type MempoolTxInfo struct {
+	types.Tx `json:"tx"`
+	Height   int64 `json:"height"`
+}

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -318,7 +318,7 @@ func MempoolTxs(limit int) (*ctypes.ResultMempoolTxs, error) {
 	if limit < 1 {
 		limit = -1 // will reap all txs in the mempool
 	}
-	txs := mempool.ReapMaxTxsWithExtInfo(limit)
+	txs := mempool.GetTxsWithExtInfo(limit)
 	return &ctypes.ResultMempoolTxs{
 		N:   mempool.Size(),
 		Txs: txs,

--- a/rpc/core/mempool.go
+++ b/rpc/core/mempool.go
@@ -278,6 +278,53 @@ func UnconfirmedTxs(limit int) (*ctypes.ResultUnconfirmedTxs, error) {
 	return &ctypes.ResultUnconfirmedTxs{len(txs), txs}, nil
 }
 
+// MempoolTxs returns the txs currently in the mempool (with additional metadata), and the total
+// number of txs currently in the mempool.
+//
+// ```shell
+// curl 'localhost:26657/mempool_txs'
+// ```
+//
+// ```go
+// client := client.NewHTTP("tcp://0.0.0.0:26657", "/websocket")
+// err := client.Start()
+// if err != nil {
+//   // handle error
+// }
+// defer client.Stop()
+// result, err := client.MempoolTxs()
+// ```
+//
+// > The above command returns JSON structured like this:
+//
+// ```json
+// {
+//   "error": "",
+//   "result": {
+//     "txs": [],
+//     "n_txs": "100"
+//   },
+//   "id": "",
+//   "jsonrpc": "2.0"
+// }
+//
+// ### Query Parameters
+//
+// | Parameter | Type | Default | Required | Description                                 |
+// |-----------+------+---------+----------+---------------------------------------------|
+// | limit     | int  | 30      | false    | Maximum number of txs to fetch (-1 for all) |
+// ```
+func MempoolTxs(limit int) (*ctypes.ResultMempoolTxs, error) {
+	if limit < 1 {
+		limit = -1 // will reap all txs in the mempool
+	}
+	txs := mempool.ReapMaxTxsWithExtInfo(limit)
+	return &ctypes.ResultMempoolTxs{
+		N:   mempool.Size(),
+		Txs: txs,
+	}, nil
+}
+
 // Get number of unconfirmed transactions.
 //
 // ```shell

--- a/rpc/core/routes.go
+++ b/rpc/core/routes.go
@@ -29,6 +29,7 @@ var Routes = map[string]*rpc.RPCFunc{
 	"consensus_params":     rpc.NewRPCFunc(ConsensusParams, "height"),
 	"unconfirmed_txs":      rpc.NewRPCFunc(UnconfirmedTxs, "limit"),
 	"num_unconfirmed_txs":  rpc.NewRPCFunc(NumUnconfirmedTxs, ""),
+	"mempool_txs":          rpc.NewRPCFunc(MempoolTxs, "limit"),
 
 	// broadcast API
 	"broadcast_tx_commit": rpc.NewRPCFunc(BroadcastTxCommit, "tx"),

--- a/rpc/core/types/responses.go
+++ b/rpc/core/types/responses.go
@@ -7,6 +7,7 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto"
 	cmn "github.com/tendermint/tendermint/libs/common"
+	"github.com/tendermint/tendermint/mempool"
 
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/state"
@@ -179,6 +180,12 @@ type ResultTxSearch struct {
 type ResultUnconfirmedTxs struct {
 	N   int        `json:"n_txs"`
 	Txs []types.Tx `json:"txs"`
+}
+
+// ResultMempoolTxs contains a list of mempool txs with additional metadata
+type ResultMempoolTxs struct {
+	N   int                     `json:"n_txs"` // total number of txs in the mempool
+	Txs []mempool.MempoolTxInfo `json:"txs"`
 }
 
 // Info abci msg


### PR DESCRIPTION
Provides similar info to the `uncofirmed_txs` RPC endpoint, but with some extra metadata for each tx (currently only the height it was added at to the mempool, but might add the origin node later).