### PR TITLE
Evict txs from the mempool if they haven't been committed after N blocks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -506,12 +506,13 @@ func DefaultFuzzConnConfig() *FuzzConnConfig {
 
 // MempoolConfig defines the configuration options for the Tendermint mempool
 type MempoolConfig struct {
-	RootDir   string `mapstructure:"home"`
-	Recheck   bool   `mapstructure:"recheck"`
-	Broadcast bool   `mapstructure:"broadcast"`
-	WalPath   string `mapstructure:"wal_dir"`
-	Size      int    `mapstructure:"size"`
-	CacheSize int    `mapstructure:"cache_size"`
+	RootDir      string `mapstructure:"home"`
+	Recheck      bool   `mapstructure:"recheck"`
+	Broadcast    bool   `mapstructure:"broadcast"`
+	WalPath      string `mapstructure:"wal_dir"`
+	Size         int    `mapstructure:"size"`
+	CacheSize    int    `mapstructure:"cache_size"`
+	TxLifeWindow int    `mapstructure:"tx_life_window"`
 }
 
 // DefaultMempoolConfig returns a default configuration for the Tendermint mempool
@@ -524,6 +525,8 @@ func DefaultMempoolConfig() *MempoolConfig {
 		// ABCI Recheck
 		Size:      5000,
 		CacheSize: 10000,
+		// Max number of blocks a tx can remain in the mempool for, zero means forever
+		TxLifeWindow: 0,
 	}
 }
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -236,6 +236,9 @@ size = {{ .Mempool.Size }}
 # size of the cache (used to filter transactions we saw earlier)
 cache_size = {{ .Mempool.CacheSize }}
 
+# max number of blocks a tx can remain in the mempool for, zero means forever
+tx_life_window = {{ .Mempool.TxLifeWindow }}
+
 ##### consensus configuration options #####
 [consensus]
 


### PR DESCRIPTION
Previously a tx was only removed from the mempool when the block it was
included in was committed by the node, or when the tx failed CheckTx
after a block was committed (which can only happen when recheck is
enabled).

Sometimes a previously committed tx is received from a peer via the
mempool reactor, possibly because the peer is lagging behind.
If recheck is disabled and the tx is not in the mempool cache then the
tx may end up sitting in the node's mempool forever.

To prevent txs from getting stuck in the mempool forever it's now
possible to specify a tx life window, this is the maximum number of
blocks the tx will be allowed to remain in the mempool. After the life
window expires the tx will be removed from the mempool, but will remain
in the mempool cache to prevent it from re-entering the mempool again.
