### PR TITLE
fix consensus halt wih no empty blocks, ref tendermint/tendermint #3199

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -714,6 +714,7 @@ func (cs *ConsensusState) handleTxsAvailable() {
 	cs.mtx.Lock()
 	defer cs.mtx.Unlock()
 	// we only need to do this for round 0
+        cs.enterNewRound(cs.Height, 0)
 	cs.enterPropose(cs.Height, 0)
 }
 


### PR DESCRIPTION
Ref https://github.com/tendermint/tendermint/issues/3199 and https://github.com/tendermint/tendermint/issues/3197, this fixes the sporadic chain halts when empty_blocks is set to false in `config.toml`.
